### PR TITLE
Bug/proguard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile project(path: ':mypossmartsdk')
+    compile 'com.mypos:mypossmartsdk:1.0.0'
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:gridlayout-v7:23.1.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,10 +13,11 @@ android {
         versionCode versionNumber
         versionName versionString
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        signingConfig signingConfigs.debug
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,5 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keepclassmembers class com.mypos.smartsdk.** { *; }

--- a/app/src/main/java/com/mypos/mypospaymentdemo/activities/MainActivity.java
+++ b/app/src/main/java/com/mypos/mypospaymentdemo/activities/MainActivity.java
@@ -52,7 +52,8 @@ public class MainActivity extends AppCompatActivity {
 
         // Register the printer result broadcast receivers
         registerReceiver(printerBroadcastReceiver, new IntentFilter(MyPOSUtil.PRINTING_DONE_BROADCAST));
-        registerReceiver(scannerBroadcastReceiver, new IntentFilter(MyPOSUtil.SCANNER_RESULT_BROADCAST));
+        // HARDCODED out since SCANNER_RESULT_BROADCAST is not defined in the Maven version of the SDK
+        registerReceiver(scannerBroadcastReceiver, new IntentFilter("com.mypos.action.SCANNER_RESULT"));
 
         setContentView(R.layout.activity_main);
 
@@ -195,7 +196,8 @@ public class MainActivity extends AppCompatActivity {
                 startGiftCards();
                 break;
             case R.id.scanner_btn:
-                sendBroadcast(new Intent(MyPOSUtil.SCANNER_BROADCAST));
+                // HARDCODED since SCANNER_BROADCAST is not defined in the Maven version of the SDK
+                sendBroadcast(new Intent("com.mypos.action.OPEN_SCANNER"));
                 break;
         }
     }


### PR DESCRIPTION
This PR shows a way to reproduce a bug when the application is built in release mode with *minification* enabled. In order to fix it I added a somewhat broad in the application's `proguard-rules.pro`file. However, this should be fixed by the library maintainers by adding their proguard rules in the library.

Additionally please note that constants `MyPOSUtil.SCANNER_RESULT_BROADCAST`and `MyPOSUtil.SCANNER_BROADCAST`are not included in the Maven version of the SDK